### PR TITLE
Use os.pathsep in PATH to fix compilation errors in MacOS

### DIFF
--- a/platform/openharmony/detect.py
+++ b/platform/openharmony/detect.py
@@ -78,7 +78,7 @@ def configure(env: "SConsEnvironment"):
     ## Compiler configuration
 
     # Save this in environment for use by other modules
-    env["ENV"]["PATH"] = f"{sdk_root}/native/llvm/bin;" + env["ENV"]["PATH"]
+    env["ENV"]["PATH"] = f"{sdk_root}/native/llvm/bin{os.pathsep}" + env["ENV"]["PATH"]
 
     env["CC"] = "clang"
     env["CXX"] = "clang++"


### PR DESCRIPTION
* Problem
MacOS has a different path separator `:` comparing with windows, hard coding it as `;` leads to compilation errors in MacOS.

* Solution
Use `os.pathsep` instead of `;`

* Test
Able to finish compilation in MacOS.